### PR TITLE
Adding decimal places to height in tooltip

### DIFF
--- a/dist/plugin.js
+++ b/dist/plugin.js
@@ -28,7 +28,7 @@ W.loadPlugin(
 /* Mounting options */
 {
   "name": "windy-plugin-skewt",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": "John C. Kealy",
   "repository": {
     "type": "git",
@@ -848,7 +848,9 @@ function () {
         return Math.round(10 * (t - 273.15)) / 10;
       });
       fetchSondeAllSondes().then(function (allSondes) {
-        console.log(allSondes.json());
+        return allSondes.json();
+      }).then(function (repose) {
+        return console.log(repose);
       });
       draw_skewT(Pascent, Tascent, Tdascent, startpressure, endpressure);
       cbarbs(Pascent, Tascent, U, V, current_timestamp, dataOptions, startpressure, endpressure);

--- a/dist/plugin.js
+++ b/dist/plugin.js
@@ -416,7 +416,7 @@ function () {
       }
 
       var z = -10.0 * Math.log(P / Pascent[0]);
-      svg.append("g").append("text").html(dataOptions.model + '\xa0\xa0\xa0' + Math.round(z) + " km \xa0\xa0  " + Math.round(P) + " hPa \xa0\xa0  " + Math.round(WSpeed) + " kt \xa0/\xa0" + Math.round(wdir) + "&#176\xa0\xa0\xa0\xa0 " + Tascent[widx] + "&#176C").attr("x", w - 0.64 * w).attr("y", 0.035 * h).attr("font-family", "sans-serif").attr("font-family", "Arial").attr("font-size", 0.03 * h + "px").attr("fill", "#cccccc").attr("id", "statsID");
+      svg.append("g").append("text").html(dataOptions.model + '\xa0\xa0\xa0' + Math.round(z * 100) / 100 + " km \xa0\xa0  " + Math.round(P) + " hPa \xa0\xa0  " + Math.round(WSpeed) + " kt \xa0/\xa0" + Math.round(wdir) + "&#176\xa0\xa0\xa0\xa0 " + Tascent[widx] + "&#176C").attr("x", w - 0.64 * w).attr("y", 0.035 * h).attr("font-family", "sans-serif").attr("font-family", "Arial").attr("font-size", 0.03 * h + "px").attr("fill", "#cccccc").attr("id", "statsID");
     }
 
     window.svgbarbs = svg.append("rect").attr('x', w).attr("height", barbsh).attr("width", barbsw).attr("fill", "#424040").attr("opacity", 1.0).attr('id', 'barbsd3');

--- a/src/dataLoader.js
+++ b/src/dataLoader.js
@@ -131,8 +131,6 @@ const activate_SkewT = latLon => {
 
         fetchSondeAllSondes().then((allSondes) => allSondes.json())
             .then(repose =>  console.log(repose));
-        });
-        
 
         // draw the skewT and the windbarbs.
         draw_skewT(Pascent, Tascent, Tdascent, startpressure, endpressure);

--- a/src/wind_barbs.js
+++ b/src/wind_barbs.js
@@ -64,7 +64,7 @@ function cbarbs(Pascent, Tascent, U, V, current_timestamp, dataOptions, cmaxP, c
         // Fill the text in using another g layer
 		svg.append("g")
 			.append("text")
-			.html(dataOptions.model+'\xa0\xa0\xa0'+Math.round(z)+" km \xa0\xa0  "+Math.round(P)+" hPa \xa0\xa0  "+Math.round(WSpeed)+" kt \xa0/\xa0"+Math.round(wdir)+"&#176\xa0\xa0\xa0\xa0 "+Tascent[widx]+"&#176C")
+			.html(dataOptions.model+'\xa0\xa0\xa0'+Math.round(z*100)/100+" km \xa0\xa0  "+Math.round(P)+" hPa \xa0\xa0  "+Math.round(WSpeed)+" kt \xa0/\xa0"+Math.round(wdir)+"&#176\xa0\xa0\xa0\xa0 "+Tascent[widx]+"&#176C")
 			.attr("x", w-0.64*w)
 			.attr("y", 0.035*h)
 			.attr("font-family", "sans-serif")


### PR DESCRIPTION
I though that adding decimals (instead of rounding to nearest integer) for the given pressure height on the tooltip would be useful.
![image](https://user-images.githubusercontent.com/76410445/102726352-db196b00-42fc-11eb-8567-5b38e71a43fd.png)

The use case I have in mind is for rough estimation of the LCL for glider pilots, who will be interested in numbers around 1-3 km, and just a single digit would be too coarse.

Also I had to fix the build by removing a line - I think it was added by mistake. Hope this helps!