### PR TITLE
replacing deprecated picker.getParams()

### DIFF
--- a/src/dataLoader.js
+++ b/src/dataLoader.js
@@ -54,7 +54,7 @@ const activate_SkewT = latLon => {
             });
         })
 
-    let { lat, lon } = picker.getParams()
+    let { lat, lon } = W.store.get("pickerLocation");
     PickerOn = true;
 
     if (zoomed) {
@@ -187,7 +187,6 @@ const activate_SkewT = latLon => {
 }
 
 // As the picker appears or moves, draw the SkewT at the new latlon point
-picker.on('pickerOpened', activate_SkewT)
 picker.on('pickerMoved', activate_SkewT)
 store.on('timestamp', function() {
     if (PickerOn) {


### PR DESCRIPTION
Replacing deprecated `picker.getParams()` to a call to the store. See https://community.windy.com/topic/19680/day-and-night-plugin-error/8.

Removing the `activate_SkewT` call from the `'pickerOpened'` event as no `'pickerLocation'` is available in it. `'pickerMoved'` is broadcast right after the open, so functionally there are no changes.